### PR TITLE
Initial UX for thread/comment votes

### DIFF
--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -3,3 +3,15 @@ export enum VoteType {
 	Downvote = 'downvote',
 	Unvote = 'unvote',
 }
+
+export function getVoteValue(voteType: VoteType) {
+	switch (voteType) {
+		case VoteType.Upvote:
+			return 1
+		case VoteType.Downvote:
+			return -1
+		case VoteType.Unvote:
+		default:
+			return 0
+	}
+}

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -4,7 +4,7 @@ export enum VoteType {
 	Unvote = 'unvote',
 }
 
-export function getVoteValue(voteType: VoteType) {
+export function getVoteValue(voteType: VoteType | undefined) {
 	switch (voteType) {
 		case VoteType.Upvote:
 			return 1

--- a/src/common/constants.ts
+++ b/src/common/constants.ts
@@ -1,0 +1,5 @@
+export enum VoteType {
+	Upvote = 'upvote',
+	Downvote = 'downvote',
+	Unvote = 'unvote',
+}

--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,0 +1,7 @@
+export function getItem(namespace: string, key: string) {
+	return localStorage.getItem(`daochan.${namespace}.${key}`)
+}
+
+export function setItem(namespace: string, key: string, value: string) {
+	localStorage.setItem(`daochan.${namespace}.${key}`, value)
+}

--- a/src/layout/common/Comment.tsx
+++ b/src/layout/common/Comment.tsx
@@ -73,7 +73,7 @@ const initialState: State = {
 	activeVotes: '0',
 }
 
-function reducer(state: State, action: { type: string; payload: any }): State {
+function reducer(state: State, action: { type: string; payload?: VoteType }): State {
 	switch (action.type) {
 		case 'SET_PENDING': {
 			const votes = BigInt(state.activeVotes)
@@ -82,6 +82,9 @@ function reducer(state: State, action: { type: string; payload: any }): State {
 			return { ...state, pendingVoteType: action.payload, pendingVotes: pendingVotes.toString() }
 		}
 		case 'SET_ACTIVE_TYPE': {
+			if (!action.payload) {
+				return state
+			}
 			return { ...state, activeVoteType: action.payload }
 		}
 		case 'ACCEPT_PENDING': {
@@ -157,10 +160,10 @@ function VoteComponent({
 			})
 
 			setItem('comment.vote', `${address}.${commentId}`, pendingVoteType) // cache the vote
-			dispatch({ type: 'ACCEPT_PENDING', payload: null })
+			dispatch({ type: 'ACCEPT_PENDING' })
 		},
 		onError: (error) => {
-			dispatch({ type: 'REJECT_PENDING', payload: null })
+			dispatch({ type: 'REJECT_PENDING' })
 			toast({
 				title: intl.formatMessage({ id: 'error-creating-comment-vote', defaultMessage: 'Error voting on comment' }),
 				status: 'error',
@@ -176,9 +179,7 @@ function VoteComponent({
 		}
 		// check local storage for the user's vote on mount/address change
 		const cachedVoteType = getItem('comment.vote', `${address}.${commentId}`) as VoteType | undefined
-		if (cachedVoteType) {
-			dispatch({ type: 'SET_ACTIVE_TYPE', payload: cachedVoteType })
-		}
+		dispatch({ type: 'SET_ACTIVE_TYPE', payload: cachedVoteType })
 	}, [address, commentId])
 
 	// set pending data and asynchronously update the vote

--- a/src/layout/common/Comment.tsx
+++ b/src/layout/common/Comment.tsx
@@ -1,0 +1,195 @@
+import { Button, Flex, Image, Spinner } from '@chakra-ui/react'
+import { APIResponse, Comment, createCommentVote } from '../../common/api'
+import { useSigner, useAccount } from 'wagmi'
+import { RxChatBubble } from 'react-icons/rx'
+import { CreateCommentModal } from '../common/CreateCommentModal'
+import { Icon, IconButton, Text, useToast } from '@chakra-ui/react'
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query'
+import { BiDownvote, BiUpvote } from 'react-icons/bi'
+import { GoArrowDown, GoArrowUp } from 'react-icons/go'
+import { VoteType } from '../../common/constants'
+import { getItem, setItem } from '../../common/storage'
+import { useState, useEffect } from 'react'
+import { useIntl } from 'react-intl'
+import { ConnectController } from './ConnectController'
+
+export function CommentComponent({ comment }: { comment: Comment }) {
+	return (
+		<>
+			{comment.image && <Image src={comment.image.url} maxWidth={250} maxHeight={250} />}
+			<p>{comment.content}</p>
+			<ConnectController>
+				<VoteComponent threadId={comment.threadId} commentId={comment.id} count={comment.votes} isDisabled={true} />
+				<ReplyToCommentButton repliedToCommentId={comment.id} isDisabled={true} />
+			</ConnectController>
+		</>
+	)
+}
+
+function ReplyToCommentButton({ repliedToCommentId, isDisabled }: { repliedToCommentId: string; isDisabled: boolean }) {
+	const intl = useIntl()
+	const [isOpen, setIsOpen] = useState(false)
+	return (
+		<>
+			<Button
+				size="xs"
+				variant="ghost"
+				bg="gray.900"
+				_hover={{ bg: 'gray.700' }}
+				leftIcon={<Icon as={RxChatBubble} w={4} h={4} color="brand.200" />}
+				isDisabled={isDisabled}
+				onClick={() => setIsOpen(true)}
+			>
+				{intl.formatMessage({
+					id: 'reply-to-comment',
+					defaultMessage: 'Reply',
+				})}
+			</Button>
+			{isOpen && (
+				<CreateCommentModal isOpen={isOpen} close={() => setIsOpen(false)} repliedToCommentId={repliedToCommentId} />
+			)}
+		</>
+	)
+}
+
+/**
+ * Voting is an interesting case because the user expects to see their vote immediately
+ * We also don't wan't to call the api to check whether they have voted or not for every thread/comment we render
+ * This would be incredibly expensive and slow
+ * So we both cache the user's votes in local storage and also render the user's votes optimistically
+ */
+function VoteComponent({
+	threadId,
+	commentId,
+	count,
+	isDisabled,
+}: {
+	threadId: string
+	commentId: string
+	count: string
+	isDisabled: boolean
+}) {
+	const toast = useToast()
+	const intl = useIntl()
+	const { data: signer } = useSigner()
+	const { address } = useAccount()
+	const [pendingVoteType, setPendingVoteType] = useState<VoteType | undefined>()
+	const [activeVoteType, setActiveVoteType] = useState<VoteType>(VoteType.Unvote)
+	const queryClient = useQueryClient()
+	const { mutate, isLoading } = useMutation({
+		mutationFn: createCommentVote,
+		onSuccess: () => {
+			if (!pendingVoteType) {
+				return
+			}
+			// store the users vote in local storage
+			// update the comment count in the query cache
+			// clear the pending vote
+
+			const votes = BigInt(count)
+			console.log(activeVoteType, pendingVoteType)
+
+			//TODO: bigint and account for unvote
+			// maybe check cache before setting to find if there is an old vote
+			queryClient.setQueryData(['comments', threadId], (oldData: InfiniteData<APIResponse<Comment[]>> | undefined) => {
+				if (!oldData) {
+					return
+				}
+				return {
+					pageParams: oldData.pageParams,
+					pages: oldData.pages.map((page) => {
+						return {
+							...page,
+							data: page.data.map((comment) => {
+								if (comment.id === commentId) {
+									return {
+										...comment,
+										votes:
+											pendingVoteType === VoteType.Upvote
+												? `${parseInt(comment.votes) + 1}`
+												: `${parseInt(comment.votes) - 1}`,
+									}
+								}
+								return comment
+							}),
+						}
+					}),
+				}
+			})
+
+			setItem('comment.vote', `${address}.${commentId}`, pendingVoteType) // cache the vote
+			setActiveVoteType(pendingVoteType) // accept the pending vote type
+			setPendingVoteType(undefined) // clear the pending vote type
+		},
+		onError: (error) => {
+			setPendingVoteType(undefined) // clear the pending vote type
+			toast({
+				title: intl.formatMessage({ id: 'error-creating-comment-vote', defaultMessage: 'Error voting on comment' }),
+				status: 'error',
+				isClosable: true,
+			})
+			console.error(error)
+		},
+	})
+
+	const onClick = (clickedVoteType: VoteType) => {
+		const newVoteType = activeVoteType === clickedVoteType ? VoteType.Unvote : clickedVoteType
+		setPendingVoteType(newVoteType)
+		mutate({ threadId, commentId, signer, voteType: newVoteType })
+	}
+
+	useEffect(() => {
+		// check local storage for the user's vote on mount/address change
+		if (address) {
+			const cachedVoteType = getItem('comment.vote', `${address}.${commentId}`) as VoteType | undefined
+			if (cachedVoteType) {
+				setActiveVoteType(cachedVoteType)
+			}
+		}
+	}, [address, commentId])
+
+	// optimistically take the pending vote type if present
+	// otherwise take the active vote type
+
+	const voteType = pendingVoteType ?? activeVoteType
+
+	return (
+		<>
+			<IconButton
+				aria-label="upvote"
+				icon={
+					voteType === VoteType.Upvote ? (
+						<Icon as={GoArrowUp} w={5} h={5} color="brand.200" />
+					) : (
+						<Icon as={BiUpvote} w={4} h={4} color="brand.200" />
+					)
+				}
+				isDisabled={isDisabled}
+				onClick={() => onClick(VoteType.Upvote)}
+				variant="ghost"
+				bg="gray.900"
+				_hover={{ bg: 'gray.800' }}
+				w={4}
+				h={4}
+			/>
+			{isLoading ? <Spinner w={2} h={2} /> : <Text as="span">{count}</Text>}
+			<IconButton
+				aria-label="downvote"
+				isDisabled={isDisabled}
+				icon={
+					voteType === VoteType.Downvote ? (
+						<Icon as={GoArrowDown} w={5} h={5} color="brand.200" />
+					) : (
+						<Icon as={BiDownvote} w={4} h={4} color="brand.200" />
+					)
+				}
+				onClick={() => onClick(VoteType.Downvote)}
+				variant="ghost"
+				bg="gray.900"
+				_hover={{ bg: 'gray.800' }}
+				w={4}
+				h={4}
+			/>
+		</>
+	)
+}

--- a/src/layout/common/ConnectController.tsx
+++ b/src/layout/common/ConnectController.tsx
@@ -1,0 +1,22 @@
+import { Box, Tooltip } from '@chakra-ui/react'
+import { Children, cloneElement } from 'react'
+import { useIntl } from 'react-intl'
+import { useAccount, useSigner } from 'wagmi'
+
+// wrapps the children with a tooltip and a disabled prop
+// indicating if the user has connected their wallet or not
+export function ConnectController({ children }: { children: React.ReactElement | React.ReactElement[] }) {
+	const intl = useIntl()
+	const { data: signer } = useSigner()
+	const { address, isConnected } = useAccount()
+	const isDisabled = !signer || !isConnected || !address
+
+	return (
+		<Tooltip
+			isDisabled={!isDisabled}
+			label={intl.formatMessage({ id: 'connect-wallet-tooltip', defaultMessage: 'Connect to your wallet' })}
+		>
+			<Box as="span">{Children.map(children, (child) => cloneElement(child, { isDisabled }))}</Box>
+		</Tooltip>
+	)
+}

--- a/src/layout/common/CreateCommentModal.tsx
+++ b/src/layout/common/CreateCommentModal.tsx
@@ -8,91 +8,21 @@ import {
 	ModalFooter,
 	Button,
 	Text,
-	Icon,
-	Tooltip,
 	useToast,
 	FormControl,
 	Input,
 } from '@chakra-ui/react'
 import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useState } from 'react'
-import { HiPlus } from 'react-icons/hi'
 import { useIntl } from 'react-intl'
 import { useParams } from 'react-router-dom'
-import { useSigner, useAccount } from 'wagmi'
-import { RxChatBubble } from 'react-icons/rx'
+import { useSigner } from 'wagmi'
 import { APIResponse, Comment, createComment } from '../../common/api'
-
-export function CreateCommentButton() {
-	const intl = useIntl()
-	const [isOpen, setIsOpen] = useState(false)
-	const { data: signer } = useSigner()
-	const { isConnected } = useAccount()
-
-	const isDisabled = !signer || !isConnected
-
-	return (
-		<>
-			<Tooltip
-				isDisabled={!isDisabled}
-				label={intl.formatMessage({ id: 'connect-wallet-tooltip', defaultMessage: 'Connect to your wallet' })}
-			>
-				<Button
-					rightIcon={<Icon as={HiPlus} mt={1} w={3} h={3} color="gray.900" />}
-					isDisabled={isDisabled}
-					onClick={() => setIsOpen(true)}
-				>
-					{intl.formatMessage({
-						id: 'create-a-comment',
-						defaultMessage: 'New Comment',
-					})}
-				</Button>
-			</Tooltip>
-			{isOpen && <CreateCommentModal isOpen={isOpen} close={() => setIsOpen(false)} />}
-		</>
-	)
-}
-
-export function ReplyToCommentButton({ repliedToCommentId }: { repliedToCommentId: string }) {
-	const intl = useIntl()
-	const [isOpen, setIsOpen] = useState(false)
-	const { data: signer } = useSigner()
-	const { isConnected } = useAccount()
-
-	const isDisabled = !signer || !isConnected
-
-	return (
-		<>
-			<Tooltip
-				isDisabled={!isDisabled}
-				label={intl.formatMessage({ id: 'connect-wallet-tooltip', defaultMessage: 'Connect to your wallet' })}
-			>
-				<Button
-					size="xs"
-					variant="ghost"
-					bg="gray.900"
-					_hover={{ bg: 'gray.700' }}
-					leftIcon={<Icon as={RxChatBubble} w={4} h={4} color="brand.200" />}
-					isDisabled={isDisabled}
-					onClick={() => setIsOpen(true)}
-				>
-					{intl.formatMessage({
-						id: 'reply-to-comment',
-						defaultMessage: 'Reply',
-					})}
-				</Button>
-			</Tooltip>
-			{isOpen && (
-				<CreateCommentModal isOpen={isOpen} close={() => setIsOpen(false)} repliedToCommentId={repliedToCommentId} />
-			)}
-		</>
-	)
-}
 
 // TODO:
 // - full form validation
 // - comment preview
-function CreateCommentModal({
+export function CreateCommentModal({
 	isOpen,
 	close,
 	repliedToCommentId,
@@ -151,8 +81,8 @@ function CreateCommentModal({
 				<ModalHeader>
 					<Text textAlign="center">
 						{intl.formatMessage({
-							id: 'create-a-new-thread',
-							defaultMessage: 'Create New Thread',
+							id: 'create-a-new-comment',
+							defaultMessage: 'Create New Comment',
 						})}
 					</Text>
 				</ModalHeader>
@@ -161,7 +91,7 @@ function CreateCommentModal({
 					<FormControl>
 						<Input
 							type="text"
-							placeholder={intl.formatMessage({ id: 'thread-content', defaultMessage: 'content' })}
+							placeholder={intl.formatMessage({ id: 'comment-content', defaultMessage: 'content' })}
 							onChange={(event) => setContent(event.target.value)}
 						/>
 						<Input

--- a/src/layout/common/CreateThreadModal.tsx
+++ b/src/layout/common/CreateThreadModal.tsx
@@ -8,53 +8,20 @@ import {
 	ModalFooter,
 	Button,
 	Text,
-	Icon,
-	Tooltip,
 	useToast,
 	FormControl,
 	Input,
 } from '@chakra-ui/react'
 import { useMutation } from '@tanstack/react-query'
 import { useState } from 'react'
-import { HiPlus } from 'react-icons/hi'
 import { useIntl } from 'react-intl'
-import { useSigner, useAccount } from 'wagmi'
+import { useSigner } from 'wagmi'
 import { createThread } from '../../common/api'
-
-export function CreateThreadButton() {
-	const intl = useIntl()
-	const [isOpen, setIsOpen] = useState(false)
-	const { data: signer } = useSigner()
-	const { isConnected } = useAccount()
-
-	const isDisabled = !signer || !isConnected
-
-	return (
-		<>
-			<Tooltip
-				isDisabled={!isDisabled}
-				label={intl.formatMessage({ id: 'connect-wallet-tooltip', defaultMessage: 'Connect to your wallet' })}
-			>
-				<Button
-					rightIcon={<Icon as={HiPlus} mt={1} w={3} h={3} color="gray.900" />}
-					isDisabled={isDisabled}
-					onClick={() => setIsOpen(true)}
-				>
-					{intl.formatMessage({
-						id: 'create-a-thread',
-						defaultMessage: 'New Thread',
-					})}
-				</Button>
-			</Tooltip>
-			<CreateThreadModal isOpen={isOpen} close={() => setIsOpen(false)} />
-		</>
-	)
-}
 
 // TODO:
 // - full form validation
 // - thread preview
-function CreateThreadModal({ isOpen, close }: { isOpen: boolean; close: () => void }) {
+export function CreateThreadModal({ isOpen, close }: { isOpen: boolean; close: () => void }) {
 	const intl = useIntl()
 	const [title, setTitle] = useState('')
 	const [content, setContent] = useState('')
@@ -65,8 +32,8 @@ function CreateThreadModal({ isOpen, close }: { isOpen: boolean; close: () => vo
 	const { mutate, isLoading } = useMutation({
 		mutationFn: createThread,
 		onSuccess: ({ data: { id } }) => {
-			window.open(`/threads/${id}`, '_blank')
 			close()
+			window.open(`/threads/${id}`, '_blank')
 		},
 		onError: (error) => {
 			toast({

--- a/src/layout/common/ThreadHeader.tsx
+++ b/src/layout/common/ThreadHeader.tsx
@@ -1,0 +1,116 @@
+import { Image } from '@chakra-ui/react'
+import { Thread } from '../../common/api'
+import { Icon, IconButton, Text, useToast } from '@chakra-ui/react'
+import { useMutation } from '@tanstack/react-query'
+import { useEffect, useState } from 'react'
+import { BiDownvote, BiUpvote } from 'react-icons/bi'
+import { GoArrowDown, GoArrowUp } from 'react-icons/go'
+import { useIntl } from 'react-intl'
+import { useAccount, useSigner } from 'wagmi'
+import { createThreadVote } from '../../common/api'
+import { VoteType } from '../../common/constants'
+import { getItem, setItem } from '../../common/storage'
+import { ConnectController } from './ConnectController'
+
+export function ThreadHeader({ thread: { id, title, image, content, votes } }: { thread: Thread }) {
+	return (
+		<>
+			<h1>{title}</h1>
+			{image && <Image src={image.url} maxWidth={250} maxHeight={250} />}
+			<p>{content}</p>
+			<ConnectController>
+				<VoteComponent threadId={id} count={votes} isDisabled={true} />
+			</ConnectController>
+		</>
+	)
+}
+
+export function VoteComponent({
+	threadId,
+	count,
+	isDisabled,
+}: {
+	threadId: string
+	count: string
+	isDisabled: boolean
+}) {
+	const toast = useToast()
+	const intl = useIntl()
+	const { data: signer } = useSigner()
+	const { address } = useAccount()
+	const [voteType, setVoteType] = useState<VoteType>(VoteType.Unvote)
+	const { mutate } = useMutation({
+		mutationFn: createThreadVote,
+		onSuccess: () => {
+			// store the users vote in local storage
+			// update the thread count in the cache
+			if (address) {
+				setItem('threadvote', `${address}.${threadId}`, voteType)
+			}
+		},
+		onError: (error) => {
+			toast({
+				title: intl.formatMessage({ id: 'error-creating-thread-vote', defaultMessage: 'Error voting on thread' }),
+				status: 'error',
+				isClosable: true,
+			})
+			console.error(error)
+		},
+	})
+
+	const onClick = (clickedVoteType: VoteType) => {
+		const newVoteType = voteType === clickedVoteType ? VoteType.Unvote : clickedVoteType
+		mutate({ threadId, signer, voteType: newVoteType })
+		setVoteType(newVoteType)
+	}
+
+	useEffect(() => {
+		// check local storage for the user's vote on mount/wallet change
+		if (address) {
+			const cachedVoteType = getItem('threadvote', `${address}.${threadId}`) as VoteType | undefined
+			if (cachedVoteType) {
+				setVoteType(cachedVoteType)
+			}
+		}
+	}, [address, threadId])
+
+	return (
+		<>
+			<IconButton
+				aria-label="upvote"
+				icon={
+					voteType === VoteType.Upvote ? (
+						<Icon as={GoArrowUp} w={5} h={5} color="brand.200" />
+					) : (
+						<Icon as={BiUpvote} w={4} h={4} color="brand.200" />
+					)
+				}
+				isDisabled={isDisabled}
+				onClick={() => onClick(VoteType.Upvote)}
+				variant="ghost"
+				bg="gray.900"
+				_hover={{ bg: 'gray.800' }}
+				w={4}
+				h={4}
+			/>
+			<Text as="span">{count}</Text>
+			<IconButton
+				aria-label="downvote"
+				icon={
+					voteType === VoteType.Downvote ? (
+						<Icon as={GoArrowDown} w={5} h={5} color="brand.200" />
+					) : (
+						<Icon as={BiDownvote} w={4} h={4} color="brand.200" />
+					)
+				}
+				isDisabled={isDisabled}
+				onClick={() => onClick(VoteType.Downvote)}
+				variant="ghost"
+				bg="gray.900"
+				_hover={{ bg: 'gray.800' }}
+				w={4}
+				h={4}
+			/>
+		</>
+	)
+}

--- a/src/layout/common/ThreadHeader.tsx
+++ b/src/layout/common/ThreadHeader.tsx
@@ -1,14 +1,14 @@
 import { Image } from '@chakra-ui/react'
-import { Thread } from '../../common/api'
-import { Icon, IconButton, Text, useToast } from '@chakra-ui/react'
-import { useMutation } from '@tanstack/react-query'
-import { useEffect, useState } from 'react'
+import { APIResponse, Thread } from '../../common/api'
+import { Icon, IconButton, useToast } from '@chakra-ui/react'
+import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query'
+import { useEffect, useReducer } from 'react'
 import { BiDownvote, BiUpvote } from 'react-icons/bi'
 import { GoArrowDown, GoArrowUp } from 'react-icons/go'
 import { useIntl } from 'react-intl'
 import { useAccount, useSigner } from 'wagmi'
 import { createThreadVote } from '../../common/api'
-import { VoteType } from '../../common/constants'
+import { getVoteValue, VoteType } from '../../common/constants'
 import { getItem, setItem } from '../../common/storage'
 import { ConnectController } from './ConnectController'
 
@@ -25,30 +25,119 @@ export function ThreadHeader({ thread: { id, title, image, content, votes } }: {
 	)
 }
 
-export function VoteComponent({
-	threadId,
-	count,
-	isDisabled,
-}: {
-	threadId: string
-	count: string
-	isDisabled: boolean
-}) {
+/**
+ * Voting is an interesting case because the user expects to see their vote immediately
+ * We also don't wan't to call the api to check whether they have voted or not for every thread/comment we render
+ * This would be incredibly expensive and slow
+ * So we both cache the user's votes in local storage and also render the user's votes optimistically
+ * by maintaining the concept of a pending vote that is accepted/rejected on success/failure of the api call
+ */
+
+type State = {
+	pendingVoteType: VoteType | undefined
+	activeVoteType: VoteType
+	pendingVotes: string | undefined
+	activeVotes: string
+}
+const initialState: State = {
+	pendingVoteType: undefined,
+	pendingVotes: undefined,
+	activeVoteType: VoteType.Unvote,
+	activeVotes: '0',
+}
+
+function reducer(state: State, action: { type: string; payload: any }): State {
+	switch (action.type) {
+		case 'SET_PENDING': {
+			const votes = BigInt(state.activeVotes)
+			const diff = getVoteValue(action.payload) - getVoteValue(state.activeVoteType)
+			const pendingVotes = votes + BigInt(diff)
+			return { ...state, pendingVoteType: action.payload, pendingVotes: pendingVotes.toString() }
+		}
+		case 'SET_ACTIVE_TYPE': {
+			return { ...state, activeVoteType: action.payload }
+		}
+		case 'ACCEPT_PENDING': {
+			if (!state.pendingVoteType || !state.pendingVotes) {
+				return state
+			}
+			return {
+				...state,
+				activeVotes: state.pendingVotes,
+				activeVoteType: state.pendingVoteType,
+				pendingVotes: undefined,
+				pendingVoteType: undefined,
+			}
+		}
+		case 'REJECT_PENDING': {
+			return { ...state, pendingVotes: undefined, pendingVoteType: undefined }
+		}
+		default: {
+			throw new Error('Invalid action type')
+		}
+	}
+}
+
+function VoteComponent({ threadId, count, isDisabled }: { threadId: string; count: string; isDisabled: boolean }) {
 	const toast = useToast()
 	const intl = useIntl()
 	const { data: signer } = useSigner()
 	const { address } = useAccount()
-	const [voteType, setVoteType] = useState<VoteType>(VoteType.Unvote)
-	const { mutate } = useMutation({
+	const [state, dispatch] = useReducer(reducer, { ...initialState, activeVotes: count })
+	const queryClient = useQueryClient()
+	const { mutate, isLoading } = useMutation({
 		mutationFn: createThreadVote,
 		onSuccess: () => {
-			// store the users vote in local storage
-			// update the thread count in the cache
-			if (address) {
-				setItem('threadvote', `${address}.${threadId}`, voteType)
+			const { pendingVoteType, pendingVotes } = state
+			if (!pendingVoteType || !pendingVotes) {
+				return
 			}
+
+			// 1. update the threads votes for BOTH the thread list and individual thread in the query cache...
+			// 2. store the users vote in local storage
+			// 3. clear the pending vote
+			queryClient.setQueryData(['threads'], (oldData: InfiniteData<APIResponse<Thread[]>> | undefined) => {
+				if (!oldData) {
+					return
+				}
+
+				return {
+					pageParams: oldData.pageParams,
+					pages: oldData.pages.map((page) => {
+						return {
+							...page,
+							data: page.data.map((thread) => {
+								if (thread.id === threadId) {
+									return {
+										...thread,
+										votes: pendingVotes,
+									}
+								}
+								return thread
+							}),
+						}
+					}),
+				}
+			})
+			queryClient.setQueryData(['threads', threadId], (oldData: APIResponse<Thread> | undefined) => {
+				if (!oldData) {
+					return
+				}
+
+				return {
+					...oldData,
+					data: {
+						...oldData.data,
+						votes: pendingVotes,
+					},
+				}
+			})
+
+			setItem('thread.vote', `${address}.${threadId}`, pendingVoteType) // cache the vote
+			dispatch({ type: 'ACCEPT_PENDING', payload: null })
 		},
 		onError: (error) => {
+			dispatch({ type: 'REJECT_PENDING', payload: null })
 			toast({
 				title: intl.formatMessage({ id: 'error-creating-thread-vote', defaultMessage: 'Error voting on thread' }),
 				status: 'error',
@@ -58,21 +147,33 @@ export function VoteComponent({
 		},
 	})
 
-	const onClick = (clickedVoteType: VoteType) => {
-		const newVoteType = voteType === clickedVoteType ? VoteType.Unvote : clickedVoteType
-		mutate({ threadId, signer, voteType: newVoteType })
-		setVoteType(newVoteType)
-	}
-
 	useEffect(() => {
-		// check local storage for the user's vote on mount/wallet change
-		if (address) {
-			const cachedVoteType = getItem('threadvote', `${address}.${threadId}`) as VoteType | undefined
-			if (cachedVoteType) {
-				setVoteType(cachedVoteType)
-			}
+		if (!address) {
+			return
+		}
+		// check local storage for the user's vote on mount/address change
+		const cachedVoteType = getItem('thread.vote', `${address}.${threadId}`) as VoteType | undefined
+		if (cachedVoteType) {
+			dispatch({ type: 'SET_ACTIVE_TYPE', payload: cachedVoteType })
 		}
 	}, [address, threadId])
+
+	// set pending data and asynchronously update the vote
+	const onClick = (clickedVoteType: VoteType) => {
+		// don't let the user fire multiple mutations at the same time
+		// we will get out of sync between storage and the api
+		if (isLoading) {
+			return
+		}
+		const newVoteType = state.activeVoteType === clickedVoteType ? VoteType.Unvote : clickedVoteType
+		dispatch({ type: 'SET_PENDING', payload: newVoteType })
+		mutate({ threadId, signer, voteType: newVoteType })
+	}
+
+	// optimistically take the pending data if present
+	// otherwise take the active data
+	const voteType = state.pendingVoteType ?? state.activeVoteType
+	const votes = state.pendingVotes ?? state.activeVotes
 
 	return (
 		<>
@@ -93,9 +194,10 @@ export function VoteComponent({
 				w={4}
 				h={4}
 			/>
-			<Text as="span">{count}</Text>
+			{votes}
 			<IconButton
 				aria-label="downvote"
+				isDisabled={isDisabled}
 				icon={
 					voteType === VoteType.Downvote ? (
 						<Icon as={GoArrowDown} w={5} h={5} color="brand.200" />
@@ -103,7 +205,6 @@ export function VoteComponent({
 						<Icon as={BiDownvote} w={4} h={4} color="brand.200" />
 					)
 				}
-				isDisabled={isDisabled}
 				onClick={() => onClick(VoteType.Downvote)}
 				variant="ghost"
 				bg="gray.900"

--- a/src/layout/common/ThreadHeader.tsx
+++ b/src/layout/common/ThreadHeader.tsx
@@ -46,7 +46,7 @@ const initialState: State = {
 	activeVotes: '0',
 }
 
-function reducer(state: State, action: { type: string; payload: any }): State {
+function reducer(state: State, action: { type: string; payload?: VoteType }): State {
 	switch (action.type) {
 		case 'SET_PENDING': {
 			const votes = BigInt(state.activeVotes)
@@ -55,6 +55,9 @@ function reducer(state: State, action: { type: string; payload: any }): State {
 			return { ...state, pendingVoteType: action.payload, pendingVotes: pendingVotes.toString() }
 		}
 		case 'SET_ACTIVE_TYPE': {
+			if (!action.payload) {
+				return state
+			}
 			return { ...state, activeVoteType: action.payload }
 		}
 		case 'ACCEPT_PENDING': {
@@ -100,7 +103,6 @@ function VoteComponent({ threadId, count, isDisabled }: { threadId: string; coun
 				if (!oldData) {
 					return
 				}
-
 				return {
 					pageParams: oldData.pageParams,
 					pages: oldData.pages.map((page) => {
@@ -123,7 +125,6 @@ function VoteComponent({ threadId, count, isDisabled }: { threadId: string; coun
 				if (!oldData) {
 					return
 				}
-
 				return {
 					...oldData,
 					data: {
@@ -134,10 +135,10 @@ function VoteComponent({ threadId, count, isDisabled }: { threadId: string; coun
 			})
 
 			setItem('thread.vote', `${address}.${threadId}`, pendingVoteType) // cache the vote
-			dispatch({ type: 'ACCEPT_PENDING', payload: null })
+			dispatch({ type: 'ACCEPT_PENDING' })
 		},
 		onError: (error) => {
-			dispatch({ type: 'REJECT_PENDING', payload: null })
+			dispatch({ type: 'REJECT_PENDING' })
 			toast({
 				title: intl.formatMessage({ id: 'error-creating-thread-vote', defaultMessage: 'Error voting on thread' }),
 				status: 'error',

--- a/src/layout/home/index.tsx
+++ b/src/layout/home/index.tsx
@@ -1,10 +1,15 @@
-import { Button, Flex, Image, LinkBox, LinkOverlay, List, ListItem, Spinner, Text } from '@chakra-ui/react'
+import { Button, Flex, LinkBox, LinkOverlay, List, ListItem, Spinner, Icon } from '@chakra-ui/react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { Fragment } from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import { getThreads } from '../../common/api'
+import { ThreadHeader } from '../common/ThreadHeader'
 import Unexpected from '../unexpected'
-import { CreateThreadButton } from './createThread'
+import { useState } from 'react'
+import { HiPlus } from 'react-icons/hi'
+import { useIntl } from 'react-intl'
+import { CreateThreadModal } from '../common/CreateThreadModal'
+import { ConnectController } from '../common/ConnectController'
 
 const THREAD_PAGE_SIZE = 10
 
@@ -35,12 +40,10 @@ export default function Home() {
 					<Fragment key={i}>
 						{group.data.map((thread) => (
 							<ListItem key={thread.id}>
-								<LinkBox>
+								<LinkBox _hover={{ bg: 'gray.700' }}>
 									<LinkOverlay as={RouterLink} to={`/threads/${thread.id}`}>
-										{thread.title}
+										<ThreadHeader thread={thread} />
 									</LinkOverlay>
-									{thread.image && <Image src={thread.image.url} maxWidth={250} maxHeight={250} />}
-									<Text as="p">{thread.content}</Text>
 								</LinkBox>
 							</ListItem>
 						))}
@@ -55,14 +58,27 @@ export default function Home() {
 	)
 }
 
+function CreateThreadButton() {
+	const intl = useIntl()
+	const [isOpen, setIsOpen] = useState(false)
+
+	return (
+		<>
+			<ConnectController>
+				<Button rightIcon={<Icon as={HiPlus} mt={1} w={3} h={3} color="gray.900" />} onClick={() => setIsOpen(true)}>
+					{intl.formatMessage({
+						id: 'create-a-thread',
+						defaultMessage: 'New Thread',
+					})}
+				</Button>
+			</ConnectController>
+			<CreateThreadModal isOpen={isOpen} close={() => setIsOpen(false)} />
+		</>
+	)
+}
+
 // TODO: Turn this into infinite scrolling
-export function MoreButton({
-	isFetchingNextPage,
-	fetchNextPage,
-}: {
-	isFetchingNextPage: boolean
-	fetchNextPage: () => void
-}) {
+function MoreButton({ isFetchingNextPage, fetchNextPage }: { isFetchingNextPage: boolean; fetchNextPage: () => void }) {
 	if (isFetchingNextPage) {
 		return <Spinner color="brand.200" />
 	}

--- a/src/layout/thread/Comments.tsx
+++ b/src/layout/thread/Comments.tsx
@@ -1,10 +1,10 @@
-import { Button, Image, Spinner } from '@chakra-ui/react'
+import { Button, Spinner } from '@chakra-ui/react'
 import { useInfiniteQuery } from '@tanstack/react-query'
 import { Fragment } from 'react'
 import { useParams } from 'react-router-dom'
 import { COMMENT_PAGE_SIZE } from '.'
 import { Comment, getCommentsByThreadId, Page } from '../../common/api'
-import { ReplyToCommentButton } from './createComment'
+import { CommentComponent } from '../common/Comment'
 
 export function Comments({ initialComments, initialPage }: { initialComments?: Comment[]; initialPage?: Page }) {
 	const { threadId } = useParams()
@@ -30,11 +30,9 @@ export function Comments({ initialComments, initialPage }: { initialComments?: C
 				data.pages.map((group, i) => (
 					<Fragment key={i}>
 						{group.data.map((comment) => (
-							<div key={comment.id}>
-								{comment.image && <Image src={comment.image.url} maxWidth={250} maxHeight={250} />}
-								<p>{comment.content}</p>
-								<ReplyToCommentButton repliedToCommentId={comment.id} />
-							</div>
+							<Fragment key={comment.id}>
+								<CommentComponent comment={comment} />
+							</Fragment>
 						))}
 					</Fragment>
 				))}
@@ -44,7 +42,7 @@ export function Comments({ initialComments, initialPage }: { initialComments?: C
 }
 
 // TODO: Turn this into infinite scrolling
-export function MoreButton({
+function MoreButton({
 	hasNextPage,
 	isFetchingNextPage,
 	fetchNextPage,

--- a/src/layout/thread/index.tsx
+++ b/src/layout/thread/index.tsx
@@ -1,10 +1,15 @@
-import { Flex, Image, Spinner } from '@chakra-ui/react'
+import { Flex, Spinner, Button, Icon } from '@chakra-ui/react'
 import { InfiniteData, QueryClient, useQuery, useQueryClient } from '@tanstack/react-query'
 import { useParams } from 'react-router-dom'
 import { APIResponse, getThreadById, Thread } from '../../common/api'
+import { ThreadHeader } from '../common/ThreadHeader'
 import Unexpected from '../unexpected'
 import { Comments } from './Comments'
-import { CreateCommentButton } from './createComment'
+import { useState } from 'react'
+import { HiPlus } from 'react-icons/hi'
+import { useIntl } from 'react-intl'
+import { CreateCommentModal } from '../common/CreateCommentModal'
+import { ConnectController } from '../common/ConnectController'
 
 export const COMMENT_PAGE_SIZE = 10
 
@@ -28,25 +33,13 @@ export default function ThreadPage() {
 
 	return (
 		<div>
-			<ThreadHeader thread={data.data} />
 			<Flex>
 				<Flex grow={1} />
 				<CreateCommentButton />
 			</Flex>
+			<ThreadHeader thread={data.data} />
 			<Comments initialComments={data.data.comments} initialPage={data.nextPage} />
 		</div>
-	)
-}
-
-function ThreadHeader({ thread }: { thread: Thread }) {
-	const { image, content, title } = thread
-
-	return (
-		<>
-			<h1>{title}</h1>
-			{image && <Image src={image.url} maxWidth={250} maxHeight={250} />}
-			<p>{content}</p>
-		</>
 	)
 }
 
@@ -77,4 +70,22 @@ async function queryFn({ threadId, offset, limit }: { threadId?: string; offset:
 	}
 
 	return getThreadById({ id: threadId, offset, limit })
+}
+
+function CreateCommentButton() {
+	const intl = useIntl()
+	const [isOpen, setIsOpen] = useState(false)
+	return (
+		<>
+			<ConnectController>
+				<Button rightIcon={<Icon as={HiPlus} mt={1} w={3} h={3} color="gray.900" />} onClick={() => setIsOpen(true)}>
+					{intl.formatMessage({
+						id: 'create-a-comment',
+						defaultMessage: 'New Comment',
+					})}
+				</Button>
+			</ConnectController>
+			{isOpen && <CreateCommentModal isOpen={isOpen} close={() => setIsOpen(false)} />}
+		</>
+	)
 }

--- a/src/layout/thread/index.tsx
+++ b/src/layout/thread/index.tsx
@@ -17,7 +17,7 @@ export default function ThreadPage() {
 	const { threadId } = useParams()
 	const queryClient = useQueryClient()
 	const { data, isLoading, isError } = useQuery({
-		queryKey: ['thread', threadId],
+		queryKey: ['threads', threadId],
 		queryFn: () => queryFn({ threadId, offset: 0, limit: COMMENT_PAGE_SIZE }),
 		initialData: () => findInitialThread(queryClient, threadId),
 		staleTime: Infinity,


### PR DESCRIPTION
Voting is an interesting case because the user expects to see their vote immediately.
We also don't wan't to call the api to check whether they have voted or not for every thread/comment we render, as
this would be incredibly expensive and slow.
So we both cache the user's votes in local storage and also render the user's votes optimistically,
by maintaining the concept of a pending vote that is accepted/rejected on success/failure of the api call