### PR TITLE
Refactors to signin flow

### DIFF
--- a/src/common/storage.ts
+++ b/src/common/storage.ts
@@ -1,7 +1,45 @@
-export function getItem(namespace: string, key: string) {
-	return localStorage.getItem(`daochan.${namespace}.${key}`)
+import { VoteType } from './constants'
+
+export function getSignature(address: string): string | undefined {
+	const value = getItem('signature', address)
+	if (!value) {
+		return
+	}
+	const { signature, expires } = JSON.parse(value)
+	if (expires < Date.now() / 1000) {
+		return
+	}
+	return signature
 }
 
-export function setItem(namespace: string, key: string, value: string) {
-	localStorage.setItem(`daochan.${namespace}.${key}`, value)
+export function setSignature(address: string, signature: string, expires: number) {
+	setItem('signature', address, JSON.stringify({ signature, expires }))
+}
+
+export function discardSignature(address: string) {
+	setItem('signature', address, '')
+}
+
+export function getCommentVoteType(address: string, commentId: string) {
+	return getItem('comment:vote', `${address}.${commentId}`) as VoteType | undefined
+}
+
+export function setCommentVoteType(address: string, commentId: string, voteType: VoteType) {
+	setItem('comment:vote', `${address}.${commentId}`, voteType)
+}
+
+export function getThreadVoteType(address: string, threadId: string) {
+	return getItem('thread:vote', `${address}.${threadId}`) as VoteType | undefined
+}
+
+export function setThreadVoteType(address: string, threadId: string, voteType: VoteType) {
+	setItem('thread:vote', `${address}.${threadId}`, voteType)
+}
+
+function getItem(namespace: string, key: string) {
+	return localStorage.getItem(`daochan:${namespace}.${key}`)
+}
+
+function setItem(namespace: string, key: string, value: string) {
+	localStorage.setItem(`daochan:${namespace}.${key}`, value)
 }

--- a/src/layout/common/Comment.tsx
+++ b/src/layout/common/Comment.tsx
@@ -8,10 +8,10 @@ import { InfiniteData, useMutation, useQueryClient } from '@tanstack/react-query
 import { BiDownvote, BiUpvote } from 'react-icons/bi'
 import { GoArrowDown, GoArrowUp } from 'react-icons/go'
 import { getVoteValue, VoteType } from '../../common/constants'
-import { getItem, setItem } from '../../common/storage'
 import { useState, useEffect, useReducer } from 'react'
 import { useIntl } from 'react-intl'
 import { ConnectController } from './ConnectController'
+import { getCommentVoteType, setCommentVoteType } from '../../common/storage'
 
 export function CommentComponent({ comment }: { comment: Comment }) {
 	return (
@@ -128,7 +128,7 @@ function VoteComponent({
 		mutationFn: createCommentVote,
 		onSuccess: () => {
 			const { pendingVoteType, pendingVotes } = state
-			if (pendingVoteType === undefined || pendingVotes === undefined) {
+			if (pendingVoteType === undefined || pendingVotes === undefined || !address) {
 				return
 			}
 
@@ -158,7 +158,7 @@ function VoteComponent({
 				}
 			})
 
-			setItem('comment.vote', `${address}.${commentId}`, pendingVoteType) // cache the vote
+			setCommentVoteType(address, commentId, pendingVoteType) // cache the vote
 			dispatch({ type: 'ACCEPT_PENDING' })
 		},
 		onError: (error) => {
@@ -177,7 +177,7 @@ function VoteComponent({
 			return
 		}
 		// check local storage for the user's vote on mount/address change
-		const cachedVoteType = getItem('comment.vote', `${address}.${commentId}`) as VoteType | undefined
+		const cachedVoteType = getCommentVoteType(address, commentId)
 		dispatch({ type: 'SET_ACTIVE_TYPE', payload: cachedVoteType })
 	}, [address, commentId])
 

--- a/src/layout/common/ThreadHeader.tsx
+++ b/src/layout/common/ThreadHeader.tsx
@@ -9,8 +9,8 @@ import { useIntl } from 'react-intl'
 import { useAccount, useSigner } from 'wagmi'
 import { createThreadVote } from '../../common/api'
 import { getVoteValue, VoteType } from '../../common/constants'
-import { getItem, setItem } from '../../common/storage'
 import { ConnectController } from './ConnectController'
+import { getThreadVoteType, setThreadVoteType } from '../../common/storage'
 
 export function ThreadHeader({ thread: { id, title, image, content, votes } }: { thread: Thread }) {
 	return (
@@ -91,7 +91,7 @@ function VoteComponent({ threadId, count, isDisabled }: { threadId: string; coun
 		mutationFn: createThreadVote,
 		onSuccess: () => {
 			const { pendingVoteType, pendingVotes } = state
-			if (pendingVoteType === undefined || pendingVotes === undefined) {
+			if (pendingVoteType === undefined || pendingVotes === undefined || !address) {
 				return
 			}
 
@@ -133,7 +133,7 @@ function VoteComponent({ threadId, count, isDisabled }: { threadId: string; coun
 				}
 			})
 
-			setItem('thread.vote', `${address}.${threadId}`, pendingVoteType) // cache the vote
+			setThreadVoteType(address, threadId, pendingVoteType) // cache the vote
 			dispatch({ type: 'ACCEPT_PENDING' })
 		},
 		onError: (error) => {
@@ -152,10 +152,8 @@ function VoteComponent({ threadId, count, isDisabled }: { threadId: string; coun
 			return
 		}
 		// check local storage for the user's vote on mount/address change
-		const cachedVoteType = getItem('thread.vote', `${address}.${threadId}`) as VoteType | undefined
-		if (cachedVoteType) {
-			dispatch({ type: 'SET_ACTIVE_TYPE', payload: cachedVoteType })
-		}
+		const cachedVoteType = getThreadVoteType(address, threadId)
+		dispatch({ type: 'SET_ACTIVE_TYPE', payload: cachedVoteType })
 	}, [address, threadId])
 
 	// set pending data and asynchronously update the vote


### PR DESCRIPTION
Now asking to sign message on wallet connection instead of at some later time when an authenticated request is made. Wiping the cached signature when disconnecting wallet and completely removing the "signin" button all together.

A bit of refactor on the storage file to make it a less leaky abstraction